### PR TITLE
[DOS-1462] Strip quotes from a jobs tube name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ email, or any other method with the owner of this repository before making a cha
 
 ## Issue Guideline
 
-Please check the [existing issues](https://github.com/tomponline/beanstalkworker/issues) to see if your feedback has already been reported.
+Please check the [existing issues](https://github.com/infinitytracking/beanstalkworker/issues) to see if your feedback has already been reported.
 
 Give as many relevant details you can, such as:
 1. What version of Go (`go version`) and `dep` (`git describe --tags`) are you using??

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-[![GoDoc](https://godoc.org/github.com/tomponline/beanstalkworker?status.svg)](https://godoc.org/github.com/tomponline/beanstalkworker)
 # beanstalkworker
 A helper library for creating beanstalkd consumer processes.
 
 ## Usage
 
-```go get -u github.com/tomponline/beanstalkworker```
+```go get -u github.com/infinitytracking/beanstalkworker```
 
 ## Docs/Examples
 
 Please see Go Docs for usage and examples:
 
-https://godoc.org/github.com/tomponline/beanstalkworker
+https://godoc.org/github.com/infinitytracking/beanstalkworker
 
 ## Aims
 

--- a/example_worker_test.go
+++ b/example_worker_test.go
@@ -1,6 +1,6 @@
 package beanstalkworker_test
 
-import "github.com/tomponline/beanstalkworker"
+import "github.com/infinitytracking/beanstalkworker"
 import "context"
 import "os"
 import "os/signal"

--- a/examples/beanstalkworker-with-context/beanstalkworker-with-context.go
+++ b/examples/beanstalkworker-with-context/beanstalkworker-with-context.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/tomponline/beanstalkworker"
+	"github.com/infinitytracking/beanstalkworker"
 )
 
 const (

--- a/examples/beanstalkworker-with-context/import-job.go
+++ b/examples/beanstalkworker-with-context/import-job.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tomponline/beanstalkworker"
+	"github.com/infinitytracking/beanstalkworker"
 )
 
 // ImportJobData represents the job data that arrives from the import-jobs queue

--- a/worker.go
+++ b/worker.go
@@ -6,6 +6,7 @@ import (
 	"github.com/beanstalkd/go-beanstalk"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -191,7 +192,7 @@ func (w *Worker) getNextJob(jobCh chan *RawJob, tubes *beanstalk.TubeSet) {
 	}
 
 	//Cache tube job was received from in the job.
-	job.tube = stats["tube"]
+	job.tube = strings.Trim(stats["tube"], "\"")
 
 	///Convert string age into time.Duration and cache in job.
 	age, err := strconv.Atoi(stats["age"])


### PR DESCRIPTION
A change to Beanstalkd v1.13 added extra quotes to a handful of stats responses: https://github.com/beanstalkd/beanstalkd/commit/4c275d5945299e4562389f9f2ca7c326173d6335 These quotes eventually make it down to [this map lookup](https://github.com/infinitytracking/beanstalkworker/blob/master/worker.go#L273), causing panics.

See the ticket comments for further context