### PR TITLE
[GP-4910] Add mock handlers for beanstalk worker and tube

### DIFF
--- a/beanstalkclient/client.go
+++ b/beanstalkclient/client.go
@@ -20,7 +20,7 @@ type beanstalkClient struct {
 	tube *beanstalk.Tube
 }
 
-func New(c *beanstalk.Conn, name string) Client {
+func New(c *beanstalk.Conn, name string) *beanstalkClient {
 	return &beanstalkClient{
 		tube: &beanstalk.Tube{Conn: c, Name: name},
 	}

--- a/beanstalkclient/client.go
+++ b/beanstalkclient/client.go
@@ -1,0 +1,55 @@
+package beanstalkclient
+
+import (
+	"time"
+
+	"github.com/beanstalkd/go-beanstalk"
+)
+
+type Client interface {
+	Put(body []byte, pri uint32, delay, ttr time.Duration) (id uint64, err error)
+	PeekReady() (id uint64, body []byte, err error)
+	PeekDelayed() (id uint64, body []byte, err error)
+	PeekBuried() (id uint64, body []byte, err error)
+	Kick(bound int) (n int, err error)
+	Stats() (map[string]string, error)
+	Pause(d time.Duration) error
+}
+
+type beanstalkClient struct {
+	tube *beanstalk.Tube
+}
+
+func New(c *beanstalk.Conn, name string) Client {
+	return &beanstalkClient{
+		tube: &beanstalk.Tube{Conn: c, Name: name},
+	}
+}
+
+func (t *beanstalkClient) Put(body []byte, pri uint32, delay, ttr time.Duration) (id uint64, err error) {
+	return t.tube.Put(body, pri, delay, ttr)
+}
+
+func (t *beanstalkClient) PeekReady() (id uint64, body []byte, err error) {
+	return t.tube.PeekReady()
+}
+
+func (t *beanstalkClient) PeekDelayed() (id uint64, body []byte, err error) {
+	return t.tube.PeekDelayed()
+}
+
+func (t *beanstalkClient) PeekBuried() (id uint64, body []byte, err error) {
+	return t.tube.PeekBuried()
+}
+
+func (t *beanstalkClient) Kick(bound int) (n int, err error) {
+	return t.tube.Kick(bound)
+}
+
+func (t *beanstalkClient) Stats() (map[string]string, error) {
+	return t.tube.Stats()
+}
+
+func (t *beanstalkClient) Pause(d time.Duration) error {
+	return t.tube.Pause(d)
+}

--- a/beanstalkclient/mock.go
+++ b/beanstalkclient/mock.go
@@ -1,0 +1,77 @@
+package beanstalkclient
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type MockClient struct {
+	Name        string
+	expectedPut *expectedPut
+}
+
+type expectedPut struct {
+	body string
+	id   uint64
+}
+
+type MockConn struct {
+}
+
+func NewMock(name string) Client {
+	return &MockClient{Name: name}
+}
+
+func NewMockWillPut(name string, body string, id uint64) Client {
+	c := &MockClient{Name: name}
+	c.ExpectPut(body, id)
+	return c
+}
+
+func (c *MockClient) Put(body []byte, pri uint32, delay, ttr time.Duration) (id uint64, err error) {
+	if c.expectedPut == nil {
+		return 0, errors.New("unexpected call to Put")
+	}
+
+	if diff := cmp.Diff(c.expectedPut.body, string(body)); diff != "" {
+		return 0, errors.New("unexpected body: " + diff)
+	}
+
+	return c.expectedPut.id, nil
+}
+
+func (c *MockClient) PeekReady() (id uint64, body []byte, err error) {
+	// Mock implementation
+	return 0, nil, errors.New("not implemented")
+}
+
+func (c *MockClient) PeekDelayed() (id uint64, body []byte, err error) {
+	// Mock implementation
+	return 0, nil, errors.New("not implemented")
+}
+
+func (c *MockClient) PeekBuried() (id uint64, body []byte, err error) {
+	// Mock implementation
+	return 0, nil, errors.New("not implemented")
+}
+
+func (c *MockClient) Kick(bound int) (n int, err error) {
+	// Mock implementation
+	return 0, errors.New("not implemented")
+}
+
+func (c *MockClient) Stats() (map[string]string, error) {
+	// Mock implementation
+	return nil, errors.New("not implemented")
+}
+
+func (c *MockClient) Pause(d time.Duration) error {
+	// Mock implementation
+	return errors.New("not implemented")
+}
+
+func (c *MockClient) ExpectPut(body string, id uint64) {
+	c.expectedPut = &expectedPut{body: body, id: id}
+}

--- a/example_worker_test.go
+++ b/example_worker_test.go
@@ -10,19 +10,19 @@ import "fmt"
 import "time"
 
 func Example_worker() {
-	//Setup context for cancelling beanstalk worker.
+	//Setup context for cancelling beanstalk Worker.
 	ctx, cancel := context.WithCancel(context.Background())
 
-	//Start up signal handler that will cleanly shutdown beanstalk worker.
+	//Start up signal handler that will cleanly shutdown beanstalk Worker.
 	go signalHandler(cancel)
 
-	//Define a new worker process - how to connect to the beanstalkd server.
+	//Define a new Worker process - how to connect to the beanstalkd server.
 	bsWorker := beanstalkworker.NewWorker("127.0.0.1:11300")
 
 	//Optional custom logger - see below.
 	bsWorker.SetLogger(&MyLogger{})
 
-	//Set concurrent worker threads to 2.
+	//Set concurrent Worker threads to 2.
 	bsWorker.SetNumWorkers(2)
 
 	//Job is deleted from the queue if unmarshal error appears. We can
@@ -43,7 +43,7 @@ func Example_worker() {
 		handler.Run(jobData)
 	})
 
-	//Run the beanstalk worker, this blocks until the context is cancelled.
+	//Run the beanstalk Worker, this blocks until the context is cancelled.
 	//It will also handle reconnecting to beanstalkd server automatically.
 	bsWorker.Run(ctx)
 }
@@ -107,7 +107,7 @@ func (handler *Job1Handler) LogError(a ...interface{}) {
 	handler.JobManager.LogError("Job1 error: ", fmt.Sprint(a...))
 }
 
-// Run is executed by the beanstalk worker when a Job1 type job is received.
+// Run is executed by the beanstalk Worker when a Job1 type job is received.
 func (handler *Job1Handler) Run(jobData Job1Data) {
 	handler.LogInfo("Starting job with commonVar value: ", handler.commonVar)
 	handler.LogInfo("Job Data received: ", jobData)

--- a/example_worker_test.go
+++ b/example_worker_test.go
@@ -61,7 +61,7 @@ func signalHandler(cancel context.CancelFunc) {
 
 //Custom Logging Example
 
-// MockLogger provides custom logging.
+// MyLogger provides custom logging.
 type MyLogger struct {
 }
 

--- a/example_worker_test.go
+++ b/example_worker_test.go
@@ -48,7 +48,7 @@ func Example_worker() {
 	bsWorker.Run(ctx)
 }
 
-//signalHandler catches OS signals for program to end.
+// signalHandler catches OS signals for program to end.
 func signalHandler(cancel context.CancelFunc) {
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
@@ -61,27 +61,27 @@ func signalHandler(cancel context.CancelFunc) {
 
 //Custom Logging Example
 
-//MyLogger provides custom logging.
+// MockLogger provides custom logging.
 type MyLogger struct {
 }
 
-//Info logs a custom info message regarding the job.
+// Info logs a custom info message regarding the job.
 func (l *MyLogger) Info(v ...interface{}) {
 	log.Print("MyInfo: ", fmt.Sprint(v...))
 }
 
-//Infof logs a custom info message regarding the job.
+// Infof logs a custom info message regarding the job.
 func (l *MyLogger) Infof(format string, v ...interface{}) {
 	format = "MyInfof: " + format
 	log.Print(fmt.Sprintf(format, v...))
 }
 
-//Error logs a custom error message regarding the job.
+// Error logs a custom error message regarding the job.
 func (l *MyLogger) Error(v ...interface{}) {
 	log.Print("MyError: ", fmt.Sprint(v...))
 }
 
-//Errorf logs a custom error message regarding the job.
+// Errorf logs a custom error message regarding the job.
 func (l *MyLogger) Errorf(format string, v ...interface{}) {
 	format = "MyErrorf: " + format
 	log.Print(fmt.Sprintf(format, v...))

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/infinitytracking/beanstalkworker
+
+go 1.22.2
+
+require github.com/beanstalkd/go-beanstalk v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/infinitytracking/beanstalkworker
 
 go 1.22.2
 
-require github.com/beanstalkd/go-beanstalk v0.2.0
+require (
+	github.com/beanstalkd/go-beanstalk v0.2.0
+	github.com/google/go-cmp v0.6.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/beanstalkd/go-beanstalk v0.2.0 h1:6UOJugnu47uNB2jJO/lxyDgeD1Yds7owYi1USELqexA=
+github.com/beanstalkd/go-beanstalk v0.2.0/go.mod h1:/G8YTyChOtpOArwLTQPY1CHB+i212+av35bkPXXj56Y=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/beanstalkd/go-beanstalk v0.2.0 h1:6UOJugnu47uNB2jJO/lxyDgeD1Yds7owYi1USELqexA=
 github.com/beanstalkd/go-beanstalk v0.2.0/go.mod h1:/G8YTyChOtpOArwLTQPY1CHB+i212+av35bkPXXj56Y=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/job_mock.go
+++ b/job_mock.go
@@ -1,8 +1,9 @@
 package beanstalkworker
 
 import (
-	"github.com/beanstalkd/go-beanstalk"
 	"time"
+
+	"github.com/beanstalkd/go-beanstalk"
 )
 
 type MockJob struct {

--- a/job_mock.go
+++ b/job_mock.go
@@ -1,0 +1,132 @@
+package beanstalkworker
+
+import (
+	"github.com/beanstalkd/go-beanstalk"
+	"time"
+)
+
+type MockJob struct {
+	id          uint64
+	err         error
+	body        *[]byte
+	tube        string
+	prio        uint32
+	releases    uint32
+	reserves    uint32
+	timeouts    uint32
+	conn        *beanstalk.Conn
+	delay       time.Duration
+	age         time.Duration
+	returnPrio  uint32
+	returnDelay time.Duration
+	log         *MockLogger
+	willDelete  bool
+	willTouch   bool
+	willRelease bool
+}
+
+func NewMockJob(body string) *MockJob {
+	jobBody := []byte(body)
+	return &MockJob{
+		body: &jobBody,
+	}
+}
+
+func NewWillDeleteMockJob(body string) *MockJob {
+	jobBody := []byte(body)
+	return &MockJob{
+		body:       &jobBody,
+		willDelete: true,
+	}
+}
+
+func NewWillTouchMockJob(body string) *MockJob {
+	jobBody := []byte(body)
+	return &MockJob{
+		body:      &jobBody,
+		willTouch: true,
+	}
+}
+
+func NewWillReleaseMockJob(body string) *MockJob {
+	jobBody := []byte(body)
+	return &MockJob{
+		body:        &jobBody,
+		willRelease: true,
+	}
+}
+
+func (job *MockJob) Delete() {
+	if job.willDelete == false {
+		job.log.Error("Could not delete job: " + "unexpected call to Delete")
+	}
+}
+
+func (job *MockJob) Touch() {
+	if job.willTouch == false {
+		job.log.Error("Could not touch job: " + "unexpected call to Touch")
+	}
+}
+
+func (job *MockJob) Release() {
+	if job.willRelease == false {
+		job.log.Error("Could not release job: " + "unexpected call to Release")
+	}
+}
+
+func (job *MockJob) LogError(a ...interface{}) {
+	job.log.Error(a)
+}
+
+func (job *MockJob) LogInfo(a ...interface{}) {
+	job.log.Info(a)
+}
+
+func (job *MockJob) GetAge() time.Duration {
+	// Mock implementation
+	return job.age
+}
+
+func (job *MockJob) GetPriority() uint32 {
+	// Mock implementation
+	return job.prio
+}
+
+func (job *MockJob) GetReleases() uint32 {
+	// Mock implementation
+	return job.releases
+}
+
+func (job *MockJob) GetReserves() uint32 {
+	// Mock implementation
+	return job.reserves
+}
+
+func (job *MockJob) GetTimeouts() uint32 {
+	// Mock implementation
+	return job.timeouts
+}
+
+func (job *MockJob) GetDelay() time.Duration {
+	// Mock implementation
+	return job.delay
+}
+
+func (job *MockJob) GetTube() string {
+	// Mock implementation
+	return job.tube
+}
+
+func (job *MockJob) GetConn() *beanstalk.Conn {
+	return job.conn
+}
+
+func (job *MockJob) SetReturnPriority(prio uint32) {
+	// Mock implementation
+	job.returnPrio = prio
+}
+
+func (job *MockJob) SetReturnDelay(delay time.Duration) {
+	// Mock implementation
+	job.returnDelay = delay
+}

--- a/worker.go
+++ b/worker.go
@@ -36,7 +36,7 @@ type worker struct {
 
 // NewWorker creates a new worker process,
 // but does not actually connect to beanstalkd server yet.
-func NewWorker(addr string) WorkerClient {
+func NewWorker(addr string) *worker {
 	return &worker{
 		addr:                 addr,
 		tubeSubs:             make(map[string]func(*RawJob)),

--- a/worker_mock.go
+++ b/worker_mock.go
@@ -108,7 +108,7 @@ func (w *MockWorker) Subscribe(tube string, cb Handler) {
 
 func (w *MockWorker) Run(ctx context.Context) {
 	if w.numWorkers <= 0 {
-		w.log.Error("No worker threads defined, cannot proceed.")
+		w.log.Error("No Worker threads defined, cannot proceed.")
 		return
 
 	}

--- a/worker_mock.go
+++ b/worker_mock.go
@@ -1,0 +1,135 @@
+package beanstalkworker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"reflect"
+	"sync"
+)
+
+// MockLogger A custom logger that must implement Info() Infof(), Error() and Errorf() to
+// implement CustomLogger
+type MockLogger struct {
+}
+
+func (l *MockLogger) Info(v ...interface{}) {
+	log.Print("Info: ", fmt.Sprint(v...))
+}
+
+func (l *MockLogger) Infof(format string, v ...interface{}) {
+	format = "Infof: " + format
+	log.Print(fmt.Sprintf(format, v...))
+}
+
+func (l *MockLogger) Error(v ...interface{}) {
+	log.Fatal("Error: ", fmt.Sprint(v...))
+}
+
+func (l *MockLogger) Errorf(format string, v ...interface{}) {
+	format = "Errorf: " + format
+	log.Fatalf(fmt.Sprintf(format, v...))
+}
+
+type MockWorker struct {
+	addr       string
+	tubeSubs   map[string]func(*MockJob)
+	tubeJobs   map[string]*MockJob
+	numWorkers int
+	wg         sync.WaitGroup
+	log        *Logger
+}
+
+func NewMockWorker() WorkerClient {
+	return &MockWorker{
+		tubeSubs: make(map[string]func(*MockJob)),
+	}
+}
+
+func NewMockWillDeleteWorker(tube, jobStr string) WorkerClient {
+	return &MockWorker{
+		tubeSubs: make(map[string]func(*MockJob)),
+		tubeJobs: map[string]*MockJob{
+			tube: NewWillDeleteMockJob(jobStr),
+		},
+		log: NewDefaultLogger(),
+	}
+}
+
+func NewMockWillTouchWorker(tube, jobStr string) WorkerClient {
+	return &MockWorker{
+		tubeSubs: make(map[string]func(*MockJob)),
+		tubeJobs: map[string]*MockJob{
+			tube: NewWillTouchMockJob(jobStr),
+		},
+		log: NewDefaultLogger(),
+	}
+}
+
+func NewMockWillReleaseWorker(tube, jobStr string) WorkerClient {
+	return &MockWorker{
+		tubeSubs: make(map[string]func(*MockJob)),
+		tubeJobs: map[string]*MockJob{
+			tube: NewWillReleaseMockJob(jobStr),
+		},
+		log: NewDefaultLogger(),
+	}
+}
+
+func (w *MockWorker) SetNumWorkers(numWorkers int) {
+	w.numWorkers = numWorkers
+}
+
+func (w *MockWorker) SetLogger(cl CustomLogger) {
+	w.log.Info = cl.Info
+	w.log.Error = cl.Error
+	w.log.Errorf = cl.Errorf
+	w.log.Infof = cl.Infof
+}
+
+func (w *MockWorker) Subscribe(tube string, cb Handler) {
+	w.tubeSubs[tube] = func(job *MockJob) {
+		jobVal := reflect.ValueOf(job)
+		cbFunc := reflect.ValueOf(cb)
+		cbType := reflect.TypeOf(cb)
+		if cbType.Kind() != reflect.Func {
+			panic("Handler needs to be a func")
+		}
+
+		dataType := cbType.In(1)
+		dataPtr := reflect.New(dataType)
+
+		if err := json.Unmarshal(*job.body, dataPtr.Interface()); err != nil {
+			job.LogError("Error decoding JSON for job: ", err, ", '", string(*job.body))
+			return
+		}
+
+		cbFunc.Call([]reflect.Value{jobVal, reflect.Indirect(dataPtr)})
+	}
+}
+
+func (w *MockWorker) Run(ctx context.Context) {
+	if w.numWorkers <= 0 {
+		w.log.Error("No worker threads defined, cannot proceed.")
+		return
+
+	}
+
+	if len(w.tubeSubs) <= 0 {
+		w.log.Error("No job subscriptions defined, cannot proceed.")
+		return
+	}
+
+	for tube, job := range w.tubeJobs {
+		w.log.Infof("Processing mock job from tube %s", tube)
+		if cb, ok := w.tubeSubs[tube]; ok {
+			cb(job)
+			ctx.Done()
+		}
+	}
+}
+
+func (w *MockWorker) SetUnmarshalErrorAction(action string) {
+	// Not implemented
+}

--- a/worker_mock.go
+++ b/worker_mock.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"sync"
 )
 
 // MockLogger A custom logger that must implement Info() Infof(), Error() and Errorf() to
@@ -33,11 +32,9 @@ func (l *MockLogger) Errorf(format string, v ...interface{}) {
 }
 
 type MockWorker struct {
-	addr       string
 	tubeSubs   map[string]func(*MockJob)
 	tubeJobs   map[string]*MockJob
 	numWorkers int
-	wg         sync.WaitGroup
 	log        *Logger
 }
 


### PR DESCRIPTION
To improve local testing with legacy Go repos, implements mock handlers for the worker and job - as well as a mockable client for interfacing with Tubes.